### PR TITLE
Fix problem with installing poetry

### DIFF
--- a/python-base/ubuntu20.04-pyston2.2/docker/scripts/install_poetry.sh
+++ b/python-base/ubuntu20.04-pyston2.2/docker/scripts/install_poetry.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2039
 set -exuo pipefail
 
-POETRY_URL="https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py"
+POETRY_URL="https://raw.githubusercontent.com/python-poetry/poetry/${POETRY_VERSION}/get-poetry.py"
 
 mkdir "${POETRY_HOME}"
 chown -R "${USER}":"${GROUP}" "${POETRY_HOME}"

--- a/python-base/ubuntu20.04-python3.9/docker/scripts/install_poetry.sh
+++ b/python-base/ubuntu20.04-python3.9/docker/scripts/install_poetry.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2039
 set -exuo pipefail
 
-POETRY_URL="https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py"
+POETRY_URL="https://raw.githubusercontent.com/python-poetry/poetry/${POETRY_VERSION}/get-poetry.py"
 
 mkdir "${POETRY_HOME}"
 chown -R "${USER}":"${GROUP}" "${POETRY_HOME}"

--- a/python-base/ubuntu22.04-python3.10/docker/scripts/install_poetry.sh
+++ b/python-base/ubuntu22.04-python3.10/docker/scripts/install_poetry.sh
@@ -3,7 +3,7 @@
 # shellcheck disable=SC2039
 set -exuo pipefail
 
-POETRY_URL="https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py"
+POETRY_URL="https://raw.githubusercontent.com/python-poetry/poetry/${POETRY_VERSION}/get-poetry.py"
 
 mkdir "${POETRY_HOME}"
 chown -R "${USER}":"${GROUP}" "${POETRY_HOME}"


### PR DESCRIPTION
Poetry just released version 1.2.0 and also switched to a new installer.

This is merely a hotfix that updates the URL to point to the installer of the respective old version so that installing the currently configured versions of Poetry works. The images should preferably be updated to use latest version of poetry instead. I'll likely submit a separate update for that later.