### PR TITLE
Avoid double download of the trivy db

### DIFF
--- a/.github/workflows/scan-images.yaml
+++ b/.github/workflows/scan-images.yaml
@@ -47,8 +47,5 @@ jobs:
           sudo apt-get update
           sudo apt-get install trivy
 
-          # Update the DB so we can skip it later
-          trivy image --download-db-only
-
       - name: Trivy security scan
         run: poetry run scan


### PR DESCRIPTION
The `poetry run scan` will run the `scan` cli command in `.src/docker_build/main.py`, which starts of by calling `update_scanner()`, which runs `trivy image --download-db-only`. Thus it's unnecessary to run it here in the pipeline as well.