### PR TITLE
Bunch of small fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         language_version: python3
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       # Clean up trailing whitespace
       - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       # Format Python files
       - id: black
@@ -69,12 +69,12 @@ repos:
       # Run prettier to format non-Python files
       - id: prettier
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 5.0.4
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
 
   - repo: https://github.com/twu/skjold
-    rev: v0.5.0
+    rev: v0.6.0
     hooks:
       - id: skjold

--- a/.src/docker_build/images.py
+++ b/.src/docker_build/images.py
@@ -3,11 +3,11 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 import humanize
+from docker_build.utils import run
 from loguru import logger
 from pydantic import BaseModel
 from yaml import load
 
-from docker_build.utils import run
 from settings import conf
 
 try:
@@ -45,7 +45,7 @@ class ImageConf:
     def __init__(self, priority: int, image: list[str]):
         self.priority = priority
         self.image = image
-        
+
     def __repr__(self):
         return f"<{':'.join(self.image)} @ {self.priority} prio>"
 
@@ -61,14 +61,18 @@ def sort_images(images_: Dict[str, List[str]]) -> List[ImageConf]:
             try:
                 images.remove(image_or_list)
             except ValueError:
-                logger.error("{image} found in PRIORITY_BUILDS is incorrect", image=image_or_list)
+                logger.error(
+                    "{image} found in PRIORITY_BUILDS is incorrect", image=image_or_list
+                )
                 raise
         else:
             for _img in image_or_list:
                 try:
                     images.remove(_img)
                 except ValueError:
-                    logger.error("{image} found in PRIORITY_BUILDS is incorrect", image=_img)
+                    logger.error(
+                        "{image} found in PRIORITY_BUILDS is incorrect", image=_img
+                    )
                     raise
 
     priority = 1
@@ -76,20 +80,32 @@ def sort_images(images_: Dict[str, List[str]]) -> List[ImageConf]:
     for image_or_list in conf.PRIORITY_BUILDS:
         if isinstance(image_or_list, str):
             try:
-                result.append(ImageConf(priority=priority, image=image_or_list.split("/", maxsplit=1)))
+                result.append(
+                    ImageConf(
+                        priority=priority, image=image_or_list.split("/", maxsplit=1)
+                    )
+                )
             except ValueError:
-                logger.error("{image} found in PRIORITY_BUILDS is incorrect", image=image_or_list)
+                logger.error(
+                    "{image} found in PRIORITY_BUILDS is incorrect", image=image_or_list
+                )
                 raise
         else:
             for _img in image_or_list:
                 try:
-                    result.append(ImageConf(priority=priority, image=_img.split("/", maxsplit=1)))
+                    result.append(
+                        ImageConf(priority=priority, image=_img.split("/", maxsplit=1))
+                    )
                 except ValueError:
-                    logger.error("{image} found in PRIORITY_BUILDS is incorrect", image=_img)
+                    logger.error(
+                        "{image} found in PRIORITY_BUILDS is incorrect", image=_img
+                    )
                     raise
         priority += 1
 
-    result += [ImageConf(priority=priority, image=img.split("/", maxsplit=1)) for img in images]
+    result += [
+        ImageConf(priority=priority, image=img.split("/", maxsplit=1)) for img in images
+    ]
 
     return result
 
@@ -169,7 +185,7 @@ def scan_image(image: str, version: str) -> bool:
                 "7m",
                 f"{docker_image(image)}:{version}",
             ],
-            cwd=f"{image}/{version}"
+            cwd=f"{image}/{version}",
         )
         return True
     except Exception:

--- a/.src/docker_build/main.py
+++ b/.src/docker_build/main.py
@@ -41,7 +41,7 @@ def init_pool(logger_, env):
 
 @build.command(help="Build docker images")
 def _build(
-        parallel: int = typer.Option(1), platform: Optional[Platform] = typer.Option(None)
+    parallel: int = typer.Option(1), platform: Optional[Platform] = typer.Option(None)
 ):
     platform = platform.value if platform else None
     images = find_images()
@@ -59,7 +59,7 @@ def _build(
 
         original_sigint_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
         with Pool(
-                parallel, initializer=init_pool, initargs=(utils.logger, os.environ)
+            parallel, initializer=init_pool, initargs=(utils.logger, os.environ)
         ) as pool:
             signal.signal(signal.SIGINT, original_sigint_handler)
 
@@ -79,9 +79,18 @@ def _build(
             max_prio = max(ic.priority for ic in sorted_images)
 
             for prio in range(1, max_prio + 1):
-                images = [img_conf.image for img_conf in sorted_images if img_conf.priority == prio]
+                images = [
+                    img_conf.image
+                    for img_conf in sorted_images
+                    if img_conf.priority == prio
+                ]
                 try:
-                    utils.logger.info("Building {c} priority {prio} images with up to {parallel} threads", c=len(images), prio=prio, parallel=parallel)
+                    utils.logger.info(
+                        "Building {c} priority {prio} images with up to {parallel} threads",
+                        c=len(images),
+                        prio=prio,
+                        parallel=parallel,
+                    )
                     _build_images(images)
                 except KeyboardInterrupt:
                     utils.logger.error("Caught KeyboardInterrupt, terminating workers")

--- a/poetry.lock
+++ b/poetry.lock
@@ -22,7 +22,6 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
@@ -40,27 +39,8 @@ category = "main"
 optional = false
 python-versions = ">=3.7"
 
-[package.dependencies]
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-
 [package.extras]
 tests = ["freezegun", "pytest", "pytest-cov"]
-
-[[package]]
-name = "importlib-metadata"
-version = "4.5.0"
-description = "Read metadata from Python packages"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
-zipp = ">=0.5"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "iniconfig"
@@ -103,9 +83,6 @@ description = "plugin and hook calling mechanisms for python"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
@@ -152,7 +129,6 @@ python-versions = ">=3.7"
 [package.dependencies]
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -214,22 +190,10 @@ python-versions = ">=3.5"
 [package.extras]
 dev = ["pytest (>=4.6.2)", "black (>=19.3b0)"]
 
-[[package]]
-name = "zipp"
-version = "3.4.1"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
-
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7"
-content-hash = "e67909bfaab15e167c1550ec2574d8461a689ee05c05350d4a170d7219a440de"
+python-versions = "^3.9"
+content-hash = "4d0c9002d96e66c867f588d26121360d58a1a07cfb10b1131626a729d5e30908"
 
 [metadata.files]
 attrs = [
@@ -245,7 +209,6 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 humanize = []
-importlib-metadata = []
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
@@ -317,4 +280,3 @@ win32-setctime = [
     {file = "win32_setctime-1.0.3-py3-none-any.whl", hash = "sha256:dc925662de0a6eb987f0b01f599c01a8236cb8c62831c22d9cada09ad958243e"},
     {file = "win32_setctime-1.0.3.tar.gz", hash = "sha256:4e88556c32fdf47f64165a2180ba4552f8bb32c1103a2fafd05723a0bd42bd4b"},
 ]
-zipp = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,6 +32,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "exceptiongroup"
+version = "1.0.4"
+description = "Backport of PEP 654 (exception groups)"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "humanize"
 version = "4.3.0"
 description = "Python humanize utilities"
@@ -88,14 +99,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 dev = ["pre-commit", "tox"]
 
 [[package]]
-name = "py"
-version = "1.10.0"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[[package]]
 name = "pydantic"
 version = "1.10.2"
 description = "Data validation and settings management using python type hints"
@@ -120,7 +123,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pytest"
-version = "7.1.3"
+version = "7.2.0"
 description = "pytest: simple powerful testing with Python"
 category = "main"
 optional = false
@@ -129,11 +132,11 @@ python-versions = ">=3.7"
 [package.dependencies]
 attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-py = ">=1.8.2"
-tomli = ">=1.0.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
@@ -193,7 +196,7 @@ dev = ["pytest (>=4.6.2)", "black (>=19.3b0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "4d0c9002d96e66c867f588d26121360d58a1a07cfb10b1131626a729d5e30908"
+content-hash = "e22591acc99956236b30c5bf4d7ce592284d6140662dacfc1462af3020557b8c"
 
 [metadata.files]
 attrs = [
@@ -208,6 +211,7 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+exceptiongroup = []
 humanize = []
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -224,10 +228,6 @@ packaging = [
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
-]
-py = [
-    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
-    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
 pydantic = []
 pyparsing = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -44,7 +44,7 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "humanize"
-version = "4.3.0"
+version = "4.4.0"
 description = "Python humanize utilities"
 category = "main"
 optional = false
@@ -159,7 +159,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "typer"
-version = "0.6.1"
+version = "0.7.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 category = "main"
 optional = false
@@ -169,10 +169,10 @@ python-versions = ">=3.6"
 click = ">=7.1.1,<9.0.0"
 
 [package.extras]
-test = ["rich (>=10.11.0,<13.0.0)", "isort (>=5.0.6,<6.0.0)", "black (>=22.3.0,<23.0.0)", "mypy (==0.910)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "coverage (>=5.2,<6.0)", "pytest-cov (>=2.10.0,<3.0.0)", "pytest (>=4.4.0,<5.4.0)", "shellingham (>=1.3.0,<2.0.0)"]
-doc = ["mdx-include (>=1.4.1,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "mkdocs (>=1.1.2,<2.0.0)"]
-dev = ["pre-commit (>=2.17.0,<3.0.0)", "flake8 (>=3.8.3,<4.0.0)", "autoflake (>=1.3.1,<2.0.0)"]
-all = ["rich (>=10.11.0,<13.0.0)", "shellingham (>=1.3.0,<2.0.0)", "colorama (>=0.4.3,<0.5.0)"]
+all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)", "rich (>=10.11.0,<13.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
+doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "pillow (>=9.3.0,<10.0.0)", "cairosvg (>=2.5.2,<3.0.0)"]
+test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "coverage (>=6.2,<7.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.910)", "black (>=22.3.0,<23.0.0)", "isort (>=5.0.6,<6.0.0)", "rich (>=10.11.0,<13.0.0)"]
 
 [[package]]
 name = "typing-extensions"
@@ -196,7 +196,7 @@ dev = ["pytest (>=4.6.2)", "black (>=19.3b0)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "e22591acc99956236b30c5bf4d7ce592284d6140662dacfc1462af3020557b8c"
+content-hash = "186fc18463f5fe743756af70a4a5c62ce4de982920dde3baaa0c2d94fad9bdc0"
 
 [metadata.files]
 attrs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{ include = "docker_build", from = ".src" }]
 [tool.poetry.dependencies]
 python = "^3.9"
 typer = "^0.6.1"
-pytest = "^7.1.3"
+pytest = "^7.2.0"
 pydantic = "^1.10.2"
 PyYAML = "^6.0"
 loguru = "^0.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,12 @@ packages = [{ include = "docker_build", from = ".src" }]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-typer = "^0.6.1"
+typer = "^0.7.0"
 pytest = "^7.2.0"
 pydantic = "^1.10.2"
 PyYAML = "^6.0"
 loguru = "^0.6.0"
-humanize = "^4.3.0"
+humanize = "^4.4.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/settings.py
+++ b/settings.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
             "python-base/ubuntu20.04-python3.9",
             "python-base/ubuntu22.04-python3.10",
             "nginx-base/alpine-nginx",
-        ]
+        ],
     ]
 
 


### PR DESCRIPTION
- Fix lockfile for Python 3.9 update
  - When the project was updated for Python 3.9 the poetry.lock was not updated to reflect this, which caused poetry to issue a warning when installing the dependencies.
- Update pytest to fix CVE-2022-42969
  - Mainly fixes complaints from Skjold about the so called CVE which in practice doesn't affect any real world projects
- Run pre-commit hooks on all files
- Update typer and humanize
- Update pre-commit hooks